### PR TITLE
Add kubectl to concourse-pulumi container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,3 +6,7 @@ CMD ["/bin/sh"]
 
 COPY bin/* /opt/resource/
 COPY lib/* /opt/resource/lib/
+
+RUN  /usr/bin/curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl \
+     && chmod +x ./kubectl  \
+     &&  mv ./kubectl /usr/local/bin/kubectl 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,4 @@ COPY lib/* /opt/resource/lib/
 
 RUN  /usr/bin/curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl \
      && chmod +x ./kubectl  \
-     &&  mv ./kubectl /usr/local/bin/kubectl 
+     &&  mv ./kubectl /usr/local/bin/kubectl

--- a/Dockerfile.mitol_provision
+++ b/Dockerfile.mitol_provision
@@ -10,3 +10,7 @@ COPY lib/* /opt/resource/lib/
 COPY --from=infra /usr/local/ /usr/local/
 
 CMD ["/bin/sh"]
+
+RUN  /usr/bin/curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl \
+     && chmod +x ./kubectl  \
+     &&  mv ./kubectl /usr/local/bin/kubectl


### PR DESCRIPTION
feat: add kubectl to concourse pulumi container.

### What are the relevant tickets?

https://github.com/mitodl/ol-infrastructure/issues/2687

### How can this be tested?

```
~/src/mit/concourse-pulumi-resource (cpatti_add_kubectl*) » docker build -t concourse-pulumi .                                                                     feoh@prometheus
[+] Building 8.1s (11/11) FINISHED                                                                                                                                  docker:default
 => [internal] load build definition from Dockerfile                                                                                                                          0.0s
 => => transferring dockerfile: 528B                                                                                                                                          0.0s
 => [internal] load metadata for docker.io/pulumi/pulumi-python:3.134.1@sha256:d511ca9487de9aa47f34f862b0d660c82a5b8e5d0b60d205a2755b6b48b3f63f                               1.1s
 => [auth] pulumi/pulumi-python:pull token for registry-1.docker.io                                                                                                           0.0s
 => [internal] load .dockerignore                                                                                                                                             0.0s
 => => transferring context: 2B                                                                                                                                               0.0s
 => [1/5] FROM docker.io/pulumi/pulumi-python:3.134.1@sha256:d511ca9487de9aa47f34f862b0d660c82a5b8e5d0b60d205a2755b6b48b3f63f                                                 5.1s
 => => resolve docker.io/pulumi/pulumi-python:3.134.1@sha256:d511ca9487de9aa47f34f862b0d660c82a5b8e5d0b60d205a2755b6b48b3f63f                                                 0.0s
 => => sha256:fdeeec85abbad3878f2008f9445f15a19a5a224d1b7e7715ac6b923072333e57 14.74MB / 14.74MB                                                                              0.8s
 => => sha256:d511ca9487de9aa47f34f862b0d660c82a5b8e5d0b60d205a2755b6b48b3f63f 743B / 743B                                                                                    0.0s
 => => sha256:e0cc5452ef7d35f50cdd6ddb3afb12697365b83fa25c23e4b9ca505fd442e1ba 7.36kB / 7.36kB                                                                                0.0s
 => => sha256:302e3ee498053a7b5332ac79e8efebec16e900289fc1ecd1c754ce8fa047fcab 29.13MB / 29.13MB                                                                              0.9s
 => => sha256:4c0965d3919510b506d8856ebc050a96e996c7dae96e4fb420882dbe7e037e67 3.51MB / 3.51MB                                                                                0.5s
 => => sha256:38e789cf6b2559a138ce3ec4af10d5d571be9248816776959866ff9f74ab0a51 2.42kB / 2.42kB                                                                                0.0s
 => => sha256:62a08b8dd4f53ad5493dabf2af00ccde91abb3771fb2187040bcf2fe94a7ced7 248B / 248B                                                                                    0.7s
 => => sha256:0ca5c0b40ad56eb0ac0e1bbddf8b56985467b4ecbead0974cd2a590d3b27dd70 121B / 121B                                                                                    0.9s
 => => sha256:ba3dcbe651c16bd241f1d1d14e7e5f316e982d8ab5fdefc44f0c50093cfa6d43 176B / 176B                                                                                    1.1s
 => => sha256:bcf3cea15759ec7b19ed4c6d3bb07d42ec99ba0ccf7d84a6d5c6934de4fe4e7e 48.66MB / 48.66MB                                                                              2.5s
 => => extracting sha256:302e3ee498053a7b5332ac79e8efebec16e900289fc1ecd1c754ce8fa047fcab                                                                                     1.0s
 => => sha256:cb0ea48542a3d441eec739ea333c57b8397151906c6507217955471bf6c0db33 47.37MB / 47.37MB                                                                              2.8s
 => => sha256:c2fb83ab8cd9c88fe261be0e7ae91f832d87d34811c85695d743aacd431ee156 43.26MB / 43.26MB                                                                              2.8s
 => => extracting sha256:4c0965d3919510b506d8856ebc050a96e996c7dae96e4fb420882dbe7e037e67                                                                                     0.1s
 => => extracting sha256:fdeeec85abbad3878f2008f9445f15a19a5a224d1b7e7715ac6b923072333e57                                                                                     0.6s
 => => sha256:e243b23ed3c75327d64a834eb6788825f71340cf8a87a81140f76680fbfc654f 26.39MB / 26.39MB                                                                              3.2s
 => => extracting sha256:62a08b8dd4f53ad5493dabf2af00ccde91abb3771fb2187040bcf2fe94a7ced7                                                                                     0.0s
 => => extracting sha256:0ca5c0b40ad56eb0ac0e1bbddf8b56985467b4ecbead0974cd2a590d3b27dd70                                                                                     0.0s
 => => extracting sha256:bcf3cea15759ec7b19ed4c6d3bb07d42ec99ba0ccf7d84a6d5c6934de4fe4e7e                                                                                     0.8s
 => => extracting sha256:cb0ea48542a3d441eec739ea333c57b8397151906c6507217955471bf6c0db33                                                                                     0.9s
 => => extracting sha256:ba3dcbe651c16bd241f1d1d14e7e5f316e982d8ab5fdefc44f0c50093cfa6d43                                                                                     0.0s
 => => extracting sha256:c2fb83ab8cd9c88fe261be0e7ae91f832d87d34811c85695d743aacd431ee156                                                                                     0.3s
 => => extracting sha256:e243b23ed3c75327d64a834eb6788825f71340cf8a87a81140f76680fbfc654f                                                                                     0.2s
 => [internal] load build context                                                                                                                                             0.0s
 => => transferring context: 11.94kB                                                                                                                                          0.0s
 => [2/5] WORKDIR /opt/resource                                                                                                                                               0.2s
 => [3/5] COPY bin/* /opt/resource/                                                                                                                                           0.0s
 => [4/5] COPY lib/* /opt/resource/lib/                                                                                                                                       0.0s
 => [5/5] RUN  /usr/bin/curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/b  1.5s
 => exporting to image                                                                                                                                                        0.1s
 => => exporting layers                                                                                                                                                       0.1s
 => => writing image sha256:20ffd8b2574ee5d384a178f9d35b2f42c1afc89ca79b99cb0cdd151d83a2df76                                                                                  0.0s
 => => naming to docker.io/library/concourse-pulumi                                                                                                                           0.0s
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
~/src/mit/concourse-pulumi-resource (cpatti_add_kubectl*) » docker run -it concourse-pulumi                                                                        feoh@prometheus
# kubectl
kubectl controls the Kubernetes cluster manager.

 Find more information at: https://kubernetes.io/docs/reference/kubectl/

Basic Commands (Beginner):
```

